### PR TITLE
Fix: Forward settings decode before spliting

### DIFF
--- a/pixel/head.html
+++ b/pixel/head.html
@@ -1,4 +1,4 @@
-<script>var forward="{{settings.forward}}"</script>
+<script>var forward=decodeURIComponent("{{settings.forward}}")</script>
 <script>partytown={forward:forward?forward.split(","):[],lib:"/_v/public/assets/v1/published/vtex.partytown@1.0.1-beta.0/public/~partytown/",debug:!1}</script>
 <script type="text/partytown">
   if (window && window.__RUNTIME__ && !window.__RUNTIME__.production) {

--- a/src/head.html
+++ b/src/head.html
@@ -1,10 +1,12 @@
-<script>var forward = "\{\{settings.forward\}\}"</script>
+<script>
+  var forward = decodeURIComponent('\{\{settings.forward\}\}')
+</script>
 <script>
   partytown = {
     forward: forward ? forward.split(',') : [],
     lib: `/_v/public/assets/v1/published/vtex.partytown@{{version}}/public/~partytown/`,
-    debug: false
-  };
+    debug: false,
+  }
 </script>
 <script type="text/partytown">
   if (window && window.__RUNTIME__ && !window.__RUNTIME__.production) {


### PR DESCRIPTION
**What problem is this solving?**
Partytown is expecting an array on **FORWARD** global variable, but nowadays is receiving just a string.

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

**Screenshots or example usage:**

**HOW IS SET ON ADMIN**
![Screenshot 2023-01-26 at 10 00 35 AM](https://user-images.githubusercontent.com/16109706/214841963-e9e9a07f-bd6f-40a1-8a5a-d93d9b4d6d37.png)

**OLD SCENARIO**
![Screenshot 2023-01-25 at 5 54 05 PM](https://user-images.githubusercontent.com/16109706/214841744-6e700da9-ae89-4635-b51f-e1ece33ffc39.png)

**NEW SCENARIO**
![Screenshot 2023-01-25 at 5 53 20 PM](https://user-images.githubusercontent.com/16109706/214841784-88c5a602-d1f1-44e5-bb18-b9f19bd21d7b.png)
